### PR TITLE
Patch cordova-fetch to output npm logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,8 @@ stage('build') {
         checkout scm
         sh "npm ci"
 
+        sh "pushd ./node_modules/cordova-fetch; patch -p0 < ../../fetch.patch; popd"
+
         def seyConfig = []
         seyConfig << "SEY_VERBOSE=1"
         seyConfig << "SEY_NOBROWSERIFY=1"

--- a/fetch.patch
+++ b/fetch.patch
@@ -1,5 +1,5 @@
 diff --git index.js index.js
-index 4853e2a..35420bc 100644
+index 4853e2a..0c4d945 100644
 --- index.js
 +++ index.js
 @@ -54,6 +54,8 @@ module.exports = function (target, dest, opts = {}) {
@@ -11,19 +11,21 @@ index 4853e2a..35420bc 100644
  // Installs the package specified by target and returns the installation path
  function installPackage (target, dest, opts) {
      return isNpmInstalled()
-@@ -67,6 +69,12 @@ function installPackage (target, dest, opts) {
-             return superspawn.spawn('npm', args, { cwd: dest });
-         })
- 
+@@ -64,7 +66,13 @@ function installPackage (target, dest, opts) {
+         .then(_ => npmArgs(target, opts))
+         .then(args => {
+             events.emit('verbose', `fetch: Installing ${target} to ${dest}`);
+-            return superspawn.spawn('npm', args, { cwd: dest });
++            return superspawn.spawn('npm', args, { cwd: dest, stdio: ['pipe', 'pipe', 1] });
++        })
++
 +        .then(output => {
 +            fs.writeFileSync(`npm-${modulecount++}.log`, output, { encoding: 'utf8' });
 +
 +            return output;
-+        })
-+
+         })
+ 
          // Resolve path to installed package
-         .then(getTargetPackageSpecFromNpmInstallOutput)
-         .then(spec => pathToInstalledPackage(spec, dest));
 @@ -75,7 +83,7 @@ function installPackage (target, dest, opts) {
  function npmArgs (target, userOptions) {
      const opts = Object.assign({ production: true }, userOptions);

--- a/fetch.patch
+++ b/fetch.patch
@@ -1,13 +1,22 @@
 diff --git index.js index.js
-index 4853e2a..a33aaf2 100644
+index 4853e2a..35420bc 100644
 --- index.js
 +++ index.js
-@@ -67,6 +67,12 @@ function installPackage (target, dest, opts) {
+@@ -54,6 +54,8 @@ module.exports = function (target, dest, opts = {}) {
+         });
+ };
+ 
++var modulecount = 0;
++
+ // Installs the package specified by target and returns the installation path
+ function installPackage (target, dest, opts) {
+     return isNpmInstalled()
+@@ -67,6 +69,12 @@ function installPackage (target, dest, opts) {
              return superspawn.spawn('npm', args, { cwd: dest });
          })
  
 +        .then(output => {
-+            fs.writeFileSync(`npm-${target}.log`, output, { encoding: 'utf8' });
++            fs.writeFileSync(`npm-${modulecount++}.log`, output, { encoding: 'utf8' });
 +
 +            return output;
 +        })
@@ -15,7 +24,7 @@ index 4853e2a..a33aaf2 100644
          // Resolve path to installed package
          .then(getTargetPackageSpecFromNpmInstallOutput)
          .then(spec => pathToInstalledPackage(spec, dest));
-@@ -75,7 +81,7 @@ function installPackage (target, dest, opts) {
+@@ -75,7 +83,7 @@ function installPackage (target, dest, opts) {
  function npmArgs (target, userOptions) {
      const opts = Object.assign({ production: true }, userOptions);
  

--- a/fetch.patch
+++ b/fetch.patch
@@ -6,22 +6,18 @@ index 4853e2a..08e26cb 100644
  
  // Installs the package specified by target and returns the installation path
  function installPackage (target, dest, opts) {
-+    const { name, rawSpec } = npa(target, dest);
-+
      return isNpmInstalled()
          // Ensure that `npm` installs to `dest` and not any of its ancestors
          .then(_ => fs.ensureDir(path.join(dest, 'node_modules')))
  
          // Run `npm` to install requested package
--        .then(_ => npmArgs(target, opts))
-+        .then(_ => npmArgs(name, opts))
+         .then(_ => npmArgs(target, opts))
          .then(args => {
--            events.emit('verbose', `fetch: Installing ${target} to ${dest}`);
+             events.emit('verbose', `fetch: Installing ${target} to ${dest}`);
 -            return superspawn.spawn('npm', args, { cwd: dest });
-+            events.emit('verbose', `fetch: Installing ${name} to ${dest}`);
 +            return superspawn.spawn('npm', args, { cwd: dest, stdio: 'inherit' });
          })
--
+ 
          // Resolve path to installed package
          .then(getTargetPackageSpecFromNpmInstallOutput)
          .then(spec => pathToInstalledPackage(spec, dest));
@@ -30,29 +26,18 @@ index 4853e2a..08e26cb 100644
      const opts = Object.assign({ production: true }, userOptions);
  
 -    const args = ['install', target];
--
--    if (opts.production) {
--        args.push('--production');
--    }
--    if (opts.save_exact) {
--        args.push('--save-exact');
--    } else if (opts.save) {
--        args.push('--save');
--    } else {
--        args.push('--no-save');
--    }
 +    const args = ['-ddd', 'install', target];
-+
-+    //if (opts.production) {
-+    //    args.push('--production');
-+    //}
-+    //if (opts.save_exact) {
-+    //    args.push('--save-exact');
-+    //} else if (opts.save) {
-+    //    args.push('--save');
-+    //} else {
-+    //    args.push('--no-save');
-+    //}
+ 
+     if (opts.production) {
+         args.push('--production');
+     }
+     if (opts.save_exact) {
+         args.push('--save-exact');
+     } else if (opts.save) {
+         args.push('--save');
+     } else {
+         args.push('--no-save');
+     }
      return args;
  }
  

--- a/fetch.patch
+++ b/fetch.patch
@@ -1,0 +1,13 @@
+diff --git index.js index.js
+index 4853e2a..3e70bae 100644
+--- index.js
++++ index.js
+@@ -75,7 +75,7 @@ function installPackage (target, dest, opts) {
+ function npmArgs (target, userOptions) {
+     const opts = Object.assign({ production: true }, userOptions);
+ 
+-    const args = ['install', target];
++    const args = ['--loglevel verbose', 'install', target];
+ 
+     if (opts.production) {
+         args.push('--production');

--- a/fetch.patch
+++ b/fetch.patch
@@ -2,6 +2,15 @@ diff --git index.js index.js
 index 4853e2a..a33aaf2 100644
 --- index.js
 +++ index.js
+@@ -75,7 +75,7 @@ function installPackage (target, dest, opts) {
+ function npmArgs (target, userOptions) {
+     const opts = Object.assign({ production: true }, userOptions);
+ 
+-    const args = ['install', target];
++    const args = ['--verbose', 'install', target];
+ 
+     if (opts.production) {
+         args.push('--production');
 @@ -67,6 +67,12 @@ function installPackage (target, dest, opts) {
              return superspawn.spawn('npm', args, { cwd: dest });
          })
@@ -15,12 +24,3 @@ index 4853e2a..a33aaf2 100644
          // Resolve path to installed package
          .then(getTargetPackageSpecFromNpmInstallOutput)
          .then(spec => pathToInstalledPackage(spec, dest));
-@@ -75,7 +81,7 @@ function installPackage (target, dest, opts) {
- function npmArgs (target, userOptions) {
-     const opts = Object.assign({ production: true }, userOptions);
- 
--    const args = ['install', target];
-+    const args = ['--verbose', 'install', target];
- 
-     if (opts.production) {
-         args.push('--production');

--- a/fetch.patch
+++ b/fetch.patch
@@ -1,16 +1,8 @@
 diff --git index.js index.js
-index 4853e2a..08e26cb 100644
+index 4853e2a..fd0892f 100644
 --- index.js
 +++ index.js
-@@ -56,17 +56,18 @@ module.exports = function (target, dest, opts = {}) {
- 
- // Installs the package specified by target and returns the installation path
- function installPackage (target, dest, opts) {
-     return isNpmInstalled()
-         // Ensure that `npm` installs to `dest` and not any of its ancestors
-         .then(_ => fs.ensureDir(path.join(dest, 'node_modules')))
- 
-         // Run `npm` to install requested package
+@@ -64,7 +64,7 @@ function installPackage (target, dest, opts) {
          .then(_ => npmArgs(target, opts))
          .then(args => {
              events.emit('verbose', `fetch: Installing ${target} to ${dest}`);
@@ -19,9 +11,7 @@ index 4853e2a..08e26cb 100644
          })
  
          // Resolve path to installed package
-         .then(getTargetPackageSpecFromNpmInstallOutput)
-         .then(spec => pathToInstalledPackage(spec, dest));
-@@ -75,18 +76,18 @@ function installPackage (target, dest, opts) {
+@@ -75,7 +75,7 @@ function installPackage (target, dest, opts) {
  function npmArgs (target, userOptions) {
      const opts = Object.assign({ production: true }, userOptions);
  
@@ -30,14 +20,3 @@ index 4853e2a..08e26cb 100644
  
      if (opts.production) {
          args.push('--production');
-     }
-     if (opts.save_exact) {
-         args.push('--save-exact');
-     } else if (opts.save) {
-         args.push('--save');
-     } else {
-         args.push('--no-save');
-     }
-     return args;
- }
- 

--- a/fetch.patch
+++ b/fetch.patch
@@ -1,5 +1,5 @@
 diff --git index.js index.js
-index 4853e2a..cd4ffd3 100644
+index 4853e2a..08e26cb 100644
 --- index.js
 +++ index.js
 @@ -56,17 +56,18 @@ module.exports = function (target, dest, opts = {}) {
@@ -41,7 +41,7 @@ index 4853e2a..cd4ffd3 100644
 -    } else {
 -        args.push('--no-save');
 -    }
-+    const args = ['--verbose', 'install', target];
++    const args = ['-ddd', 'install', target];
 +
 +    //if (opts.production) {
 +    //    args.push('--production');

--- a/fetch.patch
+++ b/fetch.patch
@@ -1,13 +1,26 @@
 diff --git index.js index.js
-index 4853e2a..3e70bae 100644
+index 4853e2a..a33aaf2 100644
 --- index.js
 +++ index.js
-@@ -75,7 +75,7 @@ function installPackage (target, dest, opts) {
+@@ -67,6 +67,12 @@ function installPackage (target, dest, opts) {
+             return superspawn.spawn('npm', args, { cwd: dest });
+         })
+ 
++        .then(output => {
++            fs.writeFileSync(`npm-${target}.log`, output, { encoding: 'utf8' });
++
++            return output;
++        })
++
+         // Resolve path to installed package
+         .then(getTargetPackageSpecFromNpmInstallOutput)
+         .then(spec => pathToInstalledPackage(spec, dest));
+@@ -75,7 +81,7 @@ function installPackage (target, dest, opts) {
  function npmArgs (target, userOptions) {
      const opts = Object.assign({ production: true }, userOptions);
  
 -    const args = ['install', target];
-+    const args = ['--loglevel verbose', 'install', target];
++    const args = ['--verbose', 'install', target];
  
      if (opts.production) {
          args.push('--production');

--- a/fetch.patch
+++ b/fetch.patch
@@ -2,15 +2,6 @@ diff --git index.js index.js
 index 4853e2a..a33aaf2 100644
 --- index.js
 +++ index.js
-@@ -75,7 +75,7 @@ function installPackage (target, dest, opts) {
- function npmArgs (target, userOptions) {
-     const opts = Object.assign({ production: true }, userOptions);
- 
--    const args = ['install', target];
-+    const args = ['--verbose', 'install', target];
- 
-     if (opts.production) {
-         args.push('--production');
 @@ -67,6 +67,12 @@ function installPackage (target, dest, opts) {
              return superspawn.spawn('npm', args, { cwd: dest });
          })
@@ -24,3 +15,12 @@ index 4853e2a..a33aaf2 100644
          // Resolve path to installed package
          .then(getTargetPackageSpecFromNpmInstallOutput)
          .then(spec => pathToInstalledPackage(spec, dest));
+@@ -75,7 +81,7 @@ function installPackage (target, dest, opts) {
+ function npmArgs (target, userOptions) {
+     const opts = Object.assign({ production: true }, userOptions);
+ 
+-    const args = ['install', target];
++    const args = ['--verbose', 'install', target];
+ 
+     if (opts.production) {
+         args.push('--production');

--- a/fetch.patch
+++ b/fetch.patch
@@ -1,19 +1,31 @@
 diff --git index.js index.js
-index 4853e2a..795b3a8 100644
+index 4853e2a..cd4ffd3 100644
 --- index.js
 +++ index.js
-@@ -64,9 +64,8 @@ function installPackage (target, dest, opts) {
-         .then(_ => npmArgs(target, opts))
+@@ -56,17 +56,18 @@ module.exports = function (target, dest, opts = {}) {
+ 
+ // Installs the package specified by target and returns the installation path
+ function installPackage (target, dest, opts) {
++    const { name, rawSpec } = npa(target, dest);
++
+     return isNpmInstalled()
+         // Ensure that `npm` installs to `dest` and not any of its ancestors
+         .then(_ => fs.ensureDir(path.join(dest, 'node_modules')))
+ 
+         // Run `npm` to install requested package
+-        .then(_ => npmArgs(target, opts))
++        .then(_ => npmArgs(name, opts))
          .then(args => {
-             events.emit('verbose', `fetch: Installing ${target} to ${dest}`);
+-            events.emit('verbose', `fetch: Installing ${target} to ${dest}`);
 -            return superspawn.spawn('npm', args, { cwd: dest });
++            events.emit('verbose', `fetch: Installing ${name} to ${dest}`);
 +            return superspawn.spawn('npm', args, { cwd: dest, stdio: 'inherit' });
          })
 -
          // Resolve path to installed package
          .then(getTargetPackageSpecFromNpmInstallOutput)
          .then(spec => pathToInstalledPackage(spec, dest));
-@@ -75,18 +74,18 @@ function installPackage (target, dest, opts) {
+@@ -75,18 +76,18 @@ function installPackage (target, dest, opts) {
  function npmArgs (target, userOptions) {
      const opts = Object.assign({ production: true }, userOptions);
  

--- a/fetch.patch
+++ b/fetch.patch
@@ -1,5 +1,5 @@
 diff --git index.js index.js
-index 4853e2a..a5be094 100644
+index 4853e2a..795b3a8 100644
 --- index.js
 +++ index.js
 @@ -64,9 +64,8 @@ function installPackage (target, dest, opts) {
@@ -13,12 +13,34 @@ index 4853e2a..a5be094 100644
          // Resolve path to installed package
          .then(getTargetPackageSpecFromNpmInstallOutput)
          .then(spec => pathToInstalledPackage(spec, dest));
-@@ -75,7 +74,7 @@ function installPackage (target, dest, opts) {
+@@ -75,18 +74,18 @@ function installPackage (target, dest, opts) {
  function npmArgs (target, userOptions) {
      const opts = Object.assign({ production: true }, userOptions);
  
 -    const args = ['install', target];
+-
+-    if (opts.production) {
+-        args.push('--production');
+-    }
+-    if (opts.save_exact) {
+-        args.push('--save-exact');
+-    } else if (opts.save) {
+-        args.push('--save');
+-    } else {
+-        args.push('--no-save');
+-    }
 +    const args = ['--verbose', 'install', target];
++
++    //if (opts.production) {
++    //    args.push('--production');
++    //}
++    //if (opts.save_exact) {
++    //    args.push('--save-exact');
++    //} else if (opts.save) {
++    //    args.push('--save');
++    //} else {
++    //    args.push('--no-save');
++    //}
+     return args;
+ }
  
-     if (opts.production) {
-         args.push('--production');

--- a/fetch.patch
+++ b/fetch.patch
@@ -1,32 +1,19 @@
 diff --git index.js index.js
-index 4853e2a..0c4d945 100644
+index 4853e2a..a5be094 100644
 --- index.js
 +++ index.js
-@@ -54,6 +54,8 @@ module.exports = function (target, dest, opts = {}) {
-         });
- };
- 
-+var modulecount = 0;
-+
- // Installs the package specified by target and returns the installation path
- function installPackage (target, dest, opts) {
-     return isNpmInstalled()
-@@ -64,7 +66,13 @@ function installPackage (target, dest, opts) {
+@@ -64,9 +64,8 @@ function installPackage (target, dest, opts) {
          .then(_ => npmArgs(target, opts))
          .then(args => {
              events.emit('verbose', `fetch: Installing ${target} to ${dest}`);
 -            return superspawn.spawn('npm', args, { cwd: dest });
-+            return superspawn.spawn('npm', args, { cwd: dest, stdio: ['pipe', 'pipe', 1] });
-+        })
-+
-+        .then(output => {
-+            fs.writeFileSync(`npm-${modulecount++}.log`, output, { encoding: 'utf8' });
-+
-+            return output;
++            return superspawn.spawn('npm', args, { cwd: dest, stdio: 'inherit' });
          })
- 
+-
          // Resolve path to installed package
-@@ -75,7 +83,7 @@ function installPackage (target, dest, opts) {
+         .then(getTargetPackageSpecFromNpmInstallOutput)
+         .then(spec => pathToInstalledPackage(spec, dest));
+@@ -75,7 +74,7 @@ function installPackage (target, dest, opts) {
  function npmArgs (target, userOptions) {
      const opts = Object.assign({ production: true }, userOptions);
  

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
             "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-            "dev": true,
             "requires": {
                 "call-me-maybe": "^1.0.1",
                 "glob-to-regexp": "^0.3.0"
@@ -17,14 +16,12 @@
         "@nodelib/fs.stat": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz",
-            "integrity": "sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==",
-            "dev": true
+            "integrity": "sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw=="
         },
         "accepts": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-            "dev": true,
             "requires": {
                 "mime-types": "~2.1.18",
                 "negotiator": "0.6.1"
@@ -33,14 +30,12 @@
         "acorn": {
             "version": "5.7.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-            "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-            "dev": true
+            "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
         },
         "acorn-jsx": {
             "version": "3.0.1",
             "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-            "dev": true,
             "requires": {
                 "acorn": "^3.0.4"
             },
@@ -48,8 +43,7 @@
                 "acorn": {
                     "version": "3.3.0",
                     "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-                    "dev": true
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
                 }
             }
         },
@@ -57,7 +51,6 @@
             "version": "5.5.2",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-            "dev": true,
             "requires": {
                 "co": "^4.6.0",
                 "fast-deep-equal": "^1.0.0",
@@ -68,38 +61,32 @@
         "ajv-keywords": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-            "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-            "dev": true
+            "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
         },
         "ansi": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-            "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
-            "dev": true
+            "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
         },
         "ansi-escapes": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-            "dev": true
+            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
         },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "dev": true
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-            "dev": true
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -107,38 +94,32 @@
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-            "dev": true
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
         },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-            "dev": true
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
         },
         "arr-union": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-            "dev": true
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
         },
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-            "dev": true
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
         },
         "array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-            "dev": true
+            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
         "array-includes": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
             "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
                 "es-abstract": "^1.7.0"
@@ -148,7 +129,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true,
             "requires": {
                 "array-uniq": "^1.0.1"
             }
@@ -156,38 +136,32 @@
         "array-uniq": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
         },
         "array-unique": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-            "dev": true
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-            "dev": true
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
         },
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-            "dev": true
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
         },
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "dev": true
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
         "babel-code-frame": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-            "dev": true,
             "requires": {
                 "chalk": "^1.1.3",
                 "esutils": "^2.0.2",
@@ -198,7 +172,6 @@
                     "version": "1.1.3",
                     "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
                     "requires": {
                         "ansi-styles": "^2.2.1",
                         "escape-string-regexp": "^1.0.2",
@@ -211,7 +184,6 @@
                     "version": "3.0.1",
                     "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -221,14 +193,12 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-            "dev": true,
             "requires": {
                 "cache-base": "^1.0.1",
                 "class-utils": "^0.3.5",
@@ -243,7 +213,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -252,7 +221,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -261,7 +229,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -270,7 +237,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -282,20 +248,17 @@
         "base64-js": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-            "dev": true
+            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
         },
         "big-integer": {
             "version": "1.6.36",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-            "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
-            "dev": true
+            "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
         },
         "body-parser": {
             "version": "1.18.3",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
             "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-            "dev": true,
             "requires": {
                 "bytes": "3.0.0",
                 "content-type": "~1.0.4",
@@ -313,7 +276,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -322,7 +284,6 @@
                     "version": "0.4.23",
                     "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
                     "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-                    "dev": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
                     }
@@ -330,8 +291,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -339,7 +299,6 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
             "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
-            "dev": true,
             "requires": {
                 "big-integer": "^1.6.7"
             }
@@ -348,7 +307,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -358,7 +316,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-            "dev": true,
             "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -376,7 +333,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -386,32 +342,27 @@
         "buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-            "dev": true
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
         },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
         },
         "builtins": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-            "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-            "dev": true
+            "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
         },
         "bytes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-            "dev": true
+            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
         },
         "cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-            "dev": true,
             "requires": {
                 "collection-visit": "^1.0.0",
                 "component-emitter": "^1.2.1",
@@ -427,14 +378,12 @@
         "call-me-maybe": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-            "dev": true
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
         },
         "caller-callsite": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
             "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-            "dev": true,
             "requires": {
                 "callsites": "^2.0.0"
             },
@@ -442,8 +391,7 @@
                 "callsites": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-                    "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-                    "dev": true
+                    "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
                 }
             }
         },
@@ -451,7 +399,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-            "dev": true,
             "requires": {
                 "callsites": "^0.2.0"
             }
@@ -459,14 +406,12 @@
         "callsites": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-            "dev": true
+            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
         },
         "chalk": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -477,7 +422,6 @@
                     "version": "3.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
                     "requires": {
                         "color-convert": "^1.9.0"
                     }
@@ -486,7 +430,6 @@
                     "version": "5.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
                     }
@@ -496,20 +439,17 @@
         "chardet": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-            "dev": true
+            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
         },
         "circular-json": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-            "dev": true
+            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
         },
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "define-property": "^0.2.5",
@@ -521,7 +461,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -532,7 +471,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-            "dev": true,
             "requires": {
                 "restore-cursor": "^2.0.0"
             }
@@ -540,20 +478,17 @@
         "cli-width": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-            "dev": true
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
         },
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-            "dev": true,
             "requires": {
                 "map-visit": "^1.0.0",
                 "object-visit": "^1.0.0"
@@ -563,7 +498,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -571,20 +505,17 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "component-emitter": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-            "dev": true
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "compressible": {
             "version": "2.0.15",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
             "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
-            "dev": true,
             "requires": {
                 "mime-db": ">= 1.36.0 < 2"
             }
@@ -593,7 +524,6 @@
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
             "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
-            "dev": true,
             "requires": {
                 "accepts": "~1.3.5",
                 "bytes": "3.0.0",
@@ -608,7 +538,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -616,22 +545,19 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -642,38 +568,32 @@
         "contains-path": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-            "dev": true
+            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
         },
         "content-disposition": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-            "dev": true
+            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
         },
         "content-type": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-            "dev": true
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
         },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-            "dev": true
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
         },
         "cookie-signature": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-            "dev": true
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
         "copy-descriptor": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-            "dev": true
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
         },
         "cordova-android": {
             "version": "7.1.1",
@@ -893,14 +813,12 @@
         "cordova-app-hello-world": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/cordova-app-hello-world/-/cordova-app-hello-world-3.12.0.tgz",
-            "integrity": "sha1-Jw4Gtnsq6UvP7mWS7TnrQjA9GG8=",
-            "dev": true
+            "integrity": "sha1-Jw4Gtnsq6UvP7mWS7TnrQjA9GG8="
         },
         "cordova-common": {
-            "version": "3.0.0-nightly.2018.10.30.9c6cda3d",
-            "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-3.0.0-nightly.2018.10.30.9c6cda3d.tgz",
-            "integrity": "sha512-Q2+VoOP75pe4ApwvfGyMdAYOjgDHrtT7CbtxVJ5SoEHqsAz0+8icWpgm2MUoZGDXnW4Cutw68W/5Evbc6E595A==",
-            "dev": true,
+            "version": "3.0.0-nightly.2018.10.31.9c6cda3d",
+            "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-3.0.0-nightly.2018.10.31.9c6cda3d.tgz",
+            "integrity": "sha512-ekoyMVc3rgB17rYVPBbtJhuIRP2iyHNtIyt3D28mgcoqZN8SWJLPnBvRe5ha3WBvMLZoo9jHtAWxlUJnTyNdvA==",
             "requires": {
                 "ansi": "^0.3.1",
                 "bplist-parser": "^0.1.0",
@@ -917,14 +835,13 @@
             }
         },
         "cordova-create": {
-            "version": "2.0.0-nightly.2018.10.30.5e3aab63",
-            "resolved": "https://registry.npmjs.org/cordova-create/-/cordova-create-2.0.0-nightly.2018.10.30.5e3aab63.tgz",
-            "integrity": "sha512-bxddlwH5SoWLD4ZZMSWAznWkqpiXIWoR4XHLcppLbRmGSAORo45LbCe4UzGkJltG4IOrcIbVqJ+yj7i5akNQUg==",
-            "dev": true,
+            "version": "2.0.0-nightly.2018.10.31.5e3aab63",
+            "resolved": "https://registry.npmjs.org/cordova-create/-/cordova-create-2.0.0-nightly.2018.10.31.5e3aab63.tgz",
+            "integrity": "sha512-3FlAUdOyItMrag2T/ebMXqggRocUwP9zjHHeMUf7UAc9//2nP9nJxj57PsAQp+yGRv5/2Fln3h7B4unZXYAzPA==",
             "requires": {
                 "cordova-app-hello-world": "^3.11.0",
-                "cordova-common": "3.0.0-nightly.2018.10.30.9c6cda3d",
-                "cordova-fetch": "2.0.0-nightly.2018.10.30.fef644a7",
+                "cordova-common": "3.0.0-nightly.2018.10.31.9c6cda3d",
+                "cordova-fetch": "2.0.0-nightly.2018.10.31.fef644a7",
                 "fs-extra": "^6.0.1",
                 "import-fresh": "^2.0.0",
                 "is-url": "^1.2.4",
@@ -935,12 +852,11 @@
             }
         },
         "cordova-fetch": {
-            "version": "2.0.0-nightly.2018.10.30.fef644a7",
-            "resolved": "https://registry.npmjs.org/cordova-fetch/-/cordova-fetch-2.0.0-nightly.2018.10.30.fef644a7.tgz",
-            "integrity": "sha512-mHjy11WRvt4/b2Mtt7Y4hrA6ebi5MxDI9zzxlx5NFrtxxcx5VbAqU8+eL3zckZ7hUu17wz2IXpCER8nM/MEk7w==",
-            "dev": true,
+            "version": "2.0.0-nightly.2018.10.31.fef644a7",
+            "resolved": "https://registry.npmjs.org/cordova-fetch/-/cordova-fetch-2.0.0-nightly.2018.10.31.fef644a7.tgz",
+            "integrity": "sha512-tQL0mBleRpNQ+EOMGtbESVXLh6JBk8MHQa1rcJILV1o3C8aWy40lhPGQFXx8Z1C2aXYhipQVhlRHvuZMECJ8IA==",
             "requires": {
-                "cordova-common": "3.0.0-nightly.2018.10.30.9c6cda3d",
+                "cordova-common": "3.0.0-nightly.2018.10.31.9c6cda3d",
                 "fs-extra": "^6.0.1",
                 "npm-package-arg": "^6.1.0",
                 "pify": "^4.0.0",
@@ -952,14 +868,12 @@
                 "pify": {
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-                    "dev": true
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
                 },
                 "resolve": {
                     "version": "1.8.1",
                     "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
                     "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-                    "dev": true,
                     "requires": {
                         "path-parse": "^1.0.5"
                     }
@@ -1274,14 +1188,13 @@
             }
         },
         "cordova-lib": {
-            "version": "9.0.0-nightly.2018.10.30.a76667d5",
-            "resolved": "https://registry.npmjs.org/cordova-lib/-/cordova-lib-9.0.0-nightly.2018.10.30.a76667d5.tgz",
-            "integrity": "sha512-oC7qU4KdebnLHdqGsjk5mQwy8wyi58IwS2p6jaDAZcfkMKhM/oYYidEcHfOC4nNJJEWzi5eJTiL9K7udix5CEg==",
-            "dev": true,
+            "version": "9.0.0-nightly.2018.10.31.a76667d5",
+            "resolved": "https://registry.npmjs.org/cordova-lib/-/cordova-lib-9.0.0-nightly.2018.10.31.a76667d5.tgz",
+            "integrity": "sha512-JTq1lTtK9tIYT41TxVU3nA13oiEcBNBZqD5yyzJao/QQ3A9bjCwVagLn02j/H2ggmZY+UriiD4pzDfGe6aTrDg==",
             "requires": {
-                "cordova-common": "3.0.0-nightly.2018.10.30.9c6cda3d",
-                "cordova-create": "2.0.0-nightly.2018.10.30.5e3aab63",
-                "cordova-fetch": "2.0.0-nightly.2018.10.30.fef644a7",
+                "cordova-common": "3.0.0-nightly.2018.10.31.9c6cda3d",
+                "cordova-create": "2.0.0-nightly.2018.10.31.5e3aab63",
+                "cordova-fetch": "2.0.0-nightly.2018.10.31.fef644a7",
                 "cordova-serve": "^2.0.0",
                 "dep-graph": "1.1.0",
                 "detect-indent": "^5.0.0",
@@ -1301,7 +1214,6 @@
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
                     "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
-                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
                         "jsonfile": "^4.0.0",
@@ -1312,7 +1224,6 @@
                     "version": "8.0.1",
                     "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
                     "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-                    "dev": true,
                     "requires": {
                         "array-union": "^1.0.1",
                         "dir-glob": "^2.0.0",
@@ -1326,8 +1237,7 @@
                 "pify": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
                 }
             }
         },
@@ -1374,7 +1284,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/cordova-serve/-/cordova-serve-2.0.1.tgz",
             "integrity": "sha512-3Xl1D5eyiQlY5ow6Kn/say0us2TqSw/zgQmyTLxbewTngQZ1CIqxmqD7EFGoCNBrB4HsdPmpiSpFCitybKQN9g==",
-            "dev": true,
             "requires": {
                 "chalk": "^1.1.1",
                 "compression": "^1.6.0",
@@ -1387,7 +1296,6 @@
                     "version": "1.1.3",
                     "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
                     "requires": {
                         "ansi-styles": "^2.2.1",
                         "escape-string-regexp": "^1.0.2",
@@ -1400,7 +1308,6 @@
                     "version": "3.0.1",
                     "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -1410,14 +1317,12 @@
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cross-spawn": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-            "dev": true,
             "requires": {
                 "lru-cache": "^4.0.1",
                 "shebang-command": "^1.2.0",
@@ -1428,7 +1333,6 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-            "dev": true,
             "requires": {
                 "array-find-index": "^1.0.1"
             }
@@ -1437,7 +1341,6 @@
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
             "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -1445,38 +1348,32 @@
         "debug-log": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-            "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
-            "dev": true
+            "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8="
         },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-            "dev": true
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "dedent": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-            "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-            "dev": true
+            "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
         },
         "deep-equal": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-            "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-            "dev": true
+            "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
         },
         "deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-            "dev": true
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
         },
         "define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -1485,7 +1382,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-            "dev": true,
             "requires": {
                 "is-descriptor": "^1.0.2",
                 "isobject": "^3.0.1"
@@ -1495,7 +1391,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1504,7 +1399,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1513,7 +1407,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -1525,14 +1418,12 @@
         "defined": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-            "dev": true
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
         },
         "deglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
             "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
-            "dev": true,
             "requires": {
                 "find-root": "^1.0.0",
                 "glob": "^7.0.5",
@@ -1546,7 +1437,6 @@
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-            "dev": true,
             "requires": {
                 "globby": "^5.0.0",
                 "is-path-cwd": "^1.0.0",
@@ -1561,7 +1451,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/dep-graph/-/dep-graph-1.1.0.tgz",
             "integrity": "sha1-+t6GqSeZqBPptCURzfPfpsyNvv4=",
-            "dev": true,
             "requires": {
                 "underscore": "1.2.1"
             },
@@ -1569,34 +1458,29 @@
                 "underscore": {
                     "version": "1.2.1",
                     "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.2.1.tgz",
-                    "integrity": "sha1-/FxrB2VnPZKi1KyLTcCqiHAuK9Q=",
-                    "dev": true
+                    "integrity": "sha1-/FxrB2VnPZKi1KyLTcCqiHAuK9Q="
                 }
             }
         },
         "depd": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-            "dev": true
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
         },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-            "dev": true
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
         },
         "detect-indent": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-            "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-            "dev": true
+            "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
         },
         "dir-glob": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
             "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-            "dev": true,
             "requires": {
                 "arrify": "^1.0.1",
                 "path-type": "^3.0.0"
@@ -1606,7 +1490,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
                     "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-                    "dev": true,
                     "requires": {
                         "pify": "^3.0.0"
                     }
@@ -1614,8 +1497,7 @@
                 "pify": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
                 }
             }
         },
@@ -1623,7 +1505,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-            "dev": true,
             "requires": {
                 "esutils": "^2.0.2"
             }
@@ -1631,14 +1512,12 @@
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-            "dev": true
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "elementtree": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
             "integrity": "sha1-mskb5uUvtuYkTE5UpKw+2K6OKcA=",
-            "dev": true,
             "requires": {
                 "sax": "1.1.4"
             }
@@ -1646,14 +1525,12 @@
         "encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-            "dev": true
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
         "endent": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/endent/-/endent-1.2.0.tgz",
             "integrity": "sha512-o6JTG7ce2GBLDfWjoB0XWcIoBXXtx59TGc8jHhDC8Pi6su4ifFNMpUvCmEr8ec5FPxpGVowGpmC7/JhKLk0iVw==",
-            "dev": true,
             "requires": {
                 "dedent": "^0.7.0",
                 "fast-json-parse": "^1.0.3",
@@ -1666,7 +1543,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -1675,7 +1551,6 @@
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-            "dev": true,
             "requires": {
                 "es-to-primitive": "^1.1.1",
                 "function-bind": "^1.1.1",
@@ -1688,7 +1563,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-            "dev": true,
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -1698,20 +1572,17 @@
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-            "dev": true
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "eslint": {
             "version": "4.18.2",
             "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
             "integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
-            "dev": true,
             "requires": {
                 "ajv": "^5.3.0",
                 "babel-code-frame": "^6.22.0",
@@ -1755,20 +1626,17 @@
         "eslint-config-standard": {
             "version": "11.0.0",
             "resolved": "http://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
-            "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
-            "dev": true
+            "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw=="
         },
         "eslint-config-standard-jsx": {
             "version": "5.0.0",
             "resolved": "http://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-5.0.0.tgz",
-            "integrity": "sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg==",
-            "dev": true
+            "integrity": "sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg=="
         },
         "eslint-import-resolver-node": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
             "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
-            "dev": true,
             "requires": {
                 "debug": "^2.6.9",
                 "resolve": "^1.5.0"
@@ -1778,7 +1646,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -1786,8 +1653,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -1795,7 +1661,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
             "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
-            "dev": true,
             "requires": {
                 "debug": "^2.6.8",
                 "pkg-dir": "^1.0.0"
@@ -1805,7 +1670,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -1813,8 +1677,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -1822,7 +1685,6 @@
             "version": "2.9.0",
             "resolved": "http://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
             "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
-            "dev": true,
             "requires": {
                 "builtin-modules": "^1.1.1",
                 "contains-path": "^0.1.0",
@@ -1840,7 +1702,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -1849,7 +1710,6 @@
                     "version": "1.5.0",
                     "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-                    "dev": true,
                     "requires": {
                         "esutils": "^2.0.2",
                         "isarray": "^1.0.0"
@@ -1858,8 +1718,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -1867,7 +1726,6 @@
             "version": "6.0.1",
             "resolved": "http://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
             "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
-            "dev": true,
             "requires": {
                 "ignore": "^3.3.6",
                 "minimatch": "^3.0.4",
@@ -1878,14 +1736,12 @@
         "eslint-plugin-promise": {
             "version": "3.7.0",
             "resolved": "http://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
-            "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
-            "dev": true
+            "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg=="
         },
         "eslint-plugin-react": {
             "version": "7.7.0",
             "resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
             "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
-            "dev": true,
             "requires": {
                 "doctrine": "^2.0.2",
                 "has": "^1.0.1",
@@ -1896,14 +1752,12 @@
         "eslint-plugin-standard": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-            "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
-            "dev": true
+            "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI="
         },
         "eslint-scope": {
             "version": "3.7.3",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
             "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
-            "dev": true,
             "requires": {
                 "esrecurse": "^4.1.0",
                 "estraverse": "^4.1.1"
@@ -1912,14 +1766,12 @@
         "eslint-visitor-keys": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-            "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-            "dev": true
+            "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
         },
         "espree": {
             "version": "3.5.4",
             "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-            "dev": true,
             "requires": {
                 "acorn": "^5.5.0",
                 "acorn-jsx": "^3.0.0"
@@ -1928,14 +1780,12 @@
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "esquery": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-            "dev": true,
             "requires": {
                 "estraverse": "^4.0.0"
             }
@@ -1944,7 +1794,6 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-            "dev": true,
             "requires": {
                 "estraverse": "^4.1.0"
             }
@@ -1952,26 +1801,22 @@
         "estraverse": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-            "dev": true
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
         },
         "esutils": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-            "dev": true
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
         },
         "etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-            "dev": true
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
         },
         "expand-brackets": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-            "dev": true,
             "requires": {
                 "debug": "^2.3.3",
                 "define-property": "^0.2.5",
@@ -1986,7 +1831,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -1995,7 +1839,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -2004,7 +1847,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -2012,8 +1854,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -2021,7 +1862,6 @@
             "version": "4.16.4",
             "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
             "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
-            "dev": true,
             "requires": {
                 "accepts": "~1.3.5",
                 "array-flatten": "1.1.1",
@@ -2059,7 +1899,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -2067,8 +1906,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -2076,7 +1914,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-            "dev": true,
             "requires": {
                 "assign-symbols": "^1.0.0",
                 "is-extendable": "^1.0.1"
@@ -2086,7 +1923,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -2097,7 +1933,6 @@
             "version": "2.2.0",
             "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-            "dev": true,
             "requires": {
                 "chardet": "^0.4.0",
                 "iconv-lite": "^0.4.17",
@@ -2108,7 +1943,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-            "dev": true,
             "requires": {
                 "array-unique": "^0.3.2",
                 "define-property": "^1.0.0",
@@ -2124,7 +1958,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -2133,7 +1966,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -2142,7 +1974,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -2151,7 +1982,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -2160,7 +1990,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -2172,14 +2001,12 @@
         "fast-deep-equal": {
             "version": "1.1.0",
             "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-            "dev": true
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "fast-glob": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.3.tgz",
             "integrity": "sha512-NiX+JXjnx43RzvVFwRWfPKo4U+1BrK5pJPsHQdKMlLoFHrrGktXglQhHliSihWAq+m1z6fHk3uwGHrtRbS9vLA==",
-            "dev": true,
             "requires": {
                 "@mrmlnc/readdir-enhanced": "^2.2.1",
                 "@nodelib/fs.stat": "^1.0.1",
@@ -2192,26 +2019,22 @@
         "fast-json-parse": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-            "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
-            "dev": true
+            "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-            "dev": true
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
         },
         "figures": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-            "dev": true,
             "requires": {
                 "escape-string-regexp": "^1.0.5"
             }
@@ -2220,7 +2043,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-            "dev": true,
             "requires": {
                 "flat-cache": "^1.2.1",
                 "object-assign": "^4.0.1"
@@ -2230,7 +2052,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-number": "^3.0.0",
@@ -2242,7 +2063,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -2253,7 +2073,6 @@
             "version": "1.1.1",
             "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-            "dev": true,
             "requires": {
                 "debug": "2.6.9",
                 "encodeurl": "~1.0.2",
@@ -2268,7 +2087,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -2276,22 +2094,19 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
         "find-root": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-            "dev": true
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
         },
         "find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-            "dev": true,
             "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
@@ -2301,7 +2116,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-            "dev": true,
             "requires": {
                 "circular-json": "^0.3.1",
                 "del": "^2.0.2",
@@ -2313,7 +2127,6 @@
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
             "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "dev": true,
             "requires": {
                 "is-callable": "^1.1.3"
             }
@@ -2321,20 +2134,17 @@
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "forwarded": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-            "dev": true
+            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
         },
         "fragment-cache": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-            "dev": true,
             "requires": {
                 "map-cache": "^0.2.2"
             }
@@ -2342,14 +2152,12 @@
         "fresh": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-            "dev": true
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
         "fs-extra": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
             "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -2359,38 +2167,32 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-            "dev": true
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
         "get-stdin": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-            "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-            "dev": true
+            "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
         },
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-            "dev": true
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
         },
         "glob": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -2404,7 +2206,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-            "dev": true,
             "requires": {
                 "is-glob": "^3.1.0",
                 "path-dirname": "^1.0.0"
@@ -2414,7 +2215,6 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.0"
                     }
@@ -2424,20 +2224,17 @@
         "glob-to-regexp": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-            "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-            "dev": true
+            "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
         },
         "globals": {
             "version": "11.8.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-            "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
-            "dev": true
+            "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
         },
         "globby": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-            "dev": true,
             "requires": {
                 "array-union": "^1.0.1",
                 "arrify": "^1.0.0",
@@ -2450,14 +2247,12 @@
         "graceful-fs": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-            "dev": true
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -2466,7 +2261,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -2474,20 +2268,17 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-            "dev": true
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
         },
         "has-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-            "dev": true,
             "requires": {
                 "get-value": "^2.0.6",
                 "has-values": "^1.0.0",
@@ -2498,7 +2289,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "kind-of": "^4.0.0"
@@ -2508,7 +2298,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -2518,14 +2307,12 @@
         "hosted-git-info": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-            "dev": true
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
         },
         "http-errors": {
             "version": "1.6.3",
             "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-            "dev": true,
             "requires": {
                 "depd": "~1.1.2",
                 "inherits": "2.0.3",
@@ -2537,7 +2324,6 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -2545,14 +2331,12 @@
         "ignore": {
             "version": "3.3.10",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-            "dev": true
+            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
         },
         "import-fresh": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
             "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-            "dev": true,
             "requires": {
                 "caller-path": "^2.0.0",
                 "resolve-from": "^3.0.0"
@@ -2562,7 +2346,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
                     "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-                    "dev": true,
                     "requires": {
                         "caller-callsite": "^2.0.0"
                     }
@@ -2570,28 +2353,24 @@
                 "resolve-from": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-                    "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-                    "dev": true
+                    "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
                 }
             }
         },
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "dev": true
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "indent-string": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-            "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-            "dev": true
+            "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -2600,14 +2379,12 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "init-package-json": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
             "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
-            "dev": true,
             "requires": {
                 "glob": "^7.1.1",
                 "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -2623,7 +2400,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-            "dev": true,
             "requires": {
                 "ansi-escapes": "^3.0.0",
                 "chalk": "^2.0.0",
@@ -2644,14 +2420,12 @@
         "ipaddr.js": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-            "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
-            "dev": true
+            "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -2660,7 +2434,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -2670,20 +2443,17 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
             "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-            "dev": true,
             "requires": {
                 "builtin-modules": "^1.0.0"
             }
@@ -2691,14 +2461,12 @@
         "is-callable": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-            "dev": true
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
         },
         "is-data-descriptor": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -2707,7 +2475,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -2717,14 +2484,12 @@
         "is-date-object": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-            "dev": true
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
         },
         "is-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-            "dev": true,
             "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -2734,34 +2499,29 @@
                 "kind-of": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
                 }
             }
         },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
         },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "dev": true
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "is-glob": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -2770,7 +2530,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -2779,7 +2538,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -2789,14 +2547,12 @@
         "is-path-cwd": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-            "dev": true
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
         },
         "is-path-in-cwd": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-            "dev": true,
             "requires": {
                 "is-path-inside": "^1.0.0"
             }
@@ -2805,7 +2561,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-            "dev": true,
             "requires": {
                 "path-is-inside": "^1.0.1"
             }
@@ -2814,7 +2569,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -2822,14 +2576,12 @@
         "is-promise": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-            "dev": true
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
         },
         "is-regex": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-            "dev": true,
             "requires": {
                 "has": "^1.0.1"
             }
@@ -2837,14 +2589,12 @@
         "is-resolvable": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-            "dev": true
+            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
         },
         "is-symbol": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.0"
             }
@@ -2852,50 +2602,42 @@
         "is-url": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-            "dev": true
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
         },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-            "dev": true
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         },
         "is-wsl": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-            "dev": true
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
         },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-            "dev": true
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-            "dev": true
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
         "js-yaml": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -2904,26 +2646,22 @@
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "json-schema-traverse": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-            "dev": true
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-            "dev": true
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
         },
         "jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6"
             }
@@ -2932,7 +2670,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
             "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-            "dev": true,
             "requires": {
                 "array-includes": "^3.0.3"
             }
@@ -2940,14 +2677,12 @@
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-            "dev": true
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
         "levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-            "dev": true,
             "requires": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
@@ -2957,7 +2692,6 @@
             "version": "2.0.0",
             "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -2969,7 +2703,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-            "dev": true,
             "requires": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -2978,22 +2711,19 @@
                 "path-exists": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-                    "dev": true
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
                 }
             }
         },
         "lodash": {
             "version": "4.17.11",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-            "dev": true
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
         "loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
@@ -3002,7 +2732,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-            "dev": true,
             "requires": {
                 "currently-unhandled": "^0.4.1",
                 "signal-exit": "^3.0.0"
@@ -3012,7 +2741,6 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-            "dev": true,
             "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -3021,14 +2749,12 @@
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-            "dev": true
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
         },
         "map-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-            "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
             }
@@ -3036,38 +2762,32 @@
         "md5-file": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
-            "integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg==",
-            "dev": true
+            "integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg=="
         },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-            "dev": true
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
         "merge-descriptors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-            "dev": true
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
         },
         "merge2": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-            "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
-            "dev": true
+            "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
         },
         "methods": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-            "dev": true
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
         },
         "micromatch": {
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -3087,20 +2807,17 @@
         "mime": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-            "dev": true
+            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "mime-db": {
             "version": "1.37.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
-            "dev": true
+            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
         },
         "mime-types": {
             "version": "2.1.21",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
             "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
-            "dev": true,
             "requires": {
                 "mime-db": "~1.37.0"
             }
@@ -3108,14 +2825,12 @@
         "mimic-fn": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-            "dev": true
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
         },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -3123,14 +2838,12 @@
         "minimist": {
             "version": "1.2.0",
             "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-            "dev": true
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mixin-deep": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-            "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
                 "is-extendable": "^1.0.1"
@@ -3140,7 +2853,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -3151,7 +2863,6 @@
             "version": "0.5.1",
             "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             },
@@ -3159,28 +2870,24 @@
                 "minimist": {
                     "version": "0.0.8",
                     "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 }
             }
         },
         "ms": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-            "dev": true
+            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "mute-stream": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-            "dev": true
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
         },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -3198,20 +2905,17 @@
         "natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
         },
         "negotiator": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-            "dev": true
+            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
         },
         "normalize-package-data": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "is-builtin-module": "^1.0.0",
@@ -3223,7 +2927,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
             "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
-            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.6.0",
                 "osenv": "^0.1.5",
@@ -3234,14 +2937,12 @@
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-            "dev": true,
             "requires": {
                 "copy-descriptor": "^0.1.0",
                 "define-property": "^0.2.5",
@@ -3252,7 +2953,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -3261,7 +2961,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3271,20 +2970,17 @@
         "object-inspect": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-            "dev": true
+            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
         },
         "object-keys": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-            "dev": true
+            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
         },
         "object-visit": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
             }
@@ -3293,7 +2989,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -3302,7 +2997,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.3.tgz",
             "integrity": "sha512-kPoflSYkAf/Onvjr4ZLaq37vDuOXjVzfwLCRuORRzYGdXkHa/vacPT0RgR+KmtkwOYFcxTMM62BRrZk8GGKHjw==",
-            "dev": true,
             "requires": {
                 "tape": "^4.8.0"
             }
@@ -3311,7 +3005,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
             "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-            "dev": true,
             "requires": {
                 "ee-first": "1.1.1"
             }
@@ -3319,14 +3012,12 @@
         "on-headers": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
-            "dev": true
+            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
         },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -3335,7 +3026,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-            "dev": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
             }
@@ -3344,7 +3034,6 @@
             "version": "5.4.0",
             "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
             "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
-            "dev": true,
             "requires": {
                 "is-wsl": "^1.1.0"
             }
@@ -3353,7 +3042,6 @@
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-            "dev": true,
             "requires": {
                 "deep-is": "~0.1.3",
                 "fast-levenshtein": "~2.0.4",
@@ -3366,20 +3054,17 @@
         "os-homedir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-            "dev": true
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-            "dev": true
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "osenv": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-            "dev": true,
             "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -3388,14 +3073,12 @@
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "p-limit": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-            "dev": true,
             "requires": {
                 "p-try": "^1.0.0"
             }
@@ -3404,7 +3087,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-            "dev": true,
             "requires": {
                 "p-limit": "^1.1.0"
             }
@@ -3412,14 +3094,12 @@
         "p-try": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-            "dev": true
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "parse-json": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "dev": true,
             "requires": {
                 "error-ex": "^1.2.0"
             }
@@ -3427,26 +3107,22 @@
         "parseurl": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-            "dev": true
+            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
         },
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-            "dev": true
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
         },
         "path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-            "dev": true
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
         "path-exists": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "dev": true,
             "requires": {
                 "pinkie-promise": "^2.0.0"
             }
@@ -3454,32 +3130,27 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-            "dev": true
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
         },
         "path-parse": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-            "dev": true
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "path-to-regexp": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-            "dev": true
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "path-type": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
             "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-            "dev": true,
             "requires": {
                 "pify": "^2.0.0"
             }
@@ -3487,20 +3158,17 @@
         "pify": {
             "version": "2.3.0",
             "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
             "requires": {
                 "pinkie": "^2.0.0"
             }
@@ -3509,7 +3177,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
             "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
-            "dev": true,
             "requires": {
                 "find-up": "^2.0.0",
                 "load-json-file": "^4.0.0"
@@ -3519,7 +3186,6 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-                    "dev": true,
                     "requires": {
                         "locate-path": "^2.0.0"
                     }
@@ -3528,7 +3194,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
                         "parse-json": "^4.0.0",
@@ -3540,7 +3205,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-                    "dev": true,
                     "requires": {
                         "error-ex": "^1.3.1",
                         "json-parse-better-errors": "^1.0.1"
@@ -3549,8 +3213,7 @@
                 "pify": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
                 }
             }
         },
@@ -3558,7 +3221,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
             "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
-            "dev": true,
             "requires": {
                 "debug-log": "^1.0.0",
                 "find-root": "^1.0.0",
@@ -3569,7 +3231,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
             "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-            "dev": true,
             "requires": {
                 "find-up": "^1.0.0"
             }
@@ -3578,7 +3239,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
             "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
-            "dev": true,
             "requires": {
                 "base64-js": "^1.2.3",
                 "xmlbuilder": "^9.0.7",
@@ -3588,38 +3248,32 @@
         "pluralize": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-            "dev": true
+            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
         },
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-            "dev": true
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-            "dev": true
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
         },
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-            "dev": true
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "progress": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-            "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
-            "dev": true
+            "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg=="
         },
         "promzard": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
             "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
-            "dev": true,
             "requires": {
                 "read": "1"
             }
@@ -3628,7 +3282,6 @@
             "version": "15.6.2",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
             "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.3.1",
                 "object-assign": "^4.1.1"
@@ -3638,7 +3291,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
             "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
-            "dev": true,
             "requires": {
                 "forwarded": "~0.1.2",
                 "ipaddr.js": "1.8.0"
@@ -3647,32 +3299,27 @@
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "q": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-            "dev": true
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-            "dev": true
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "range-parser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-            "dev": true
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
         },
         "raw-body": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
             "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-            "dev": true,
             "requires": {
                 "bytes": "3.0.0",
                 "http-errors": "1.6.3",
@@ -3684,7 +3331,6 @@
                     "version": "0.4.23",
                     "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
                     "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-                    "dev": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
                     }
@@ -3695,7 +3341,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-            "dev": true,
             "requires": {
                 "mute-stream": "~0.0.4"
             }
@@ -3704,7 +3349,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.0.0.tgz",
             "integrity": "sha512-8lBUVPjj9TC5bKLBacB+rpexM03+LWiYbv6ma3BeWmUYXGxqA1WNNgIZHq/iIsCrbFMzPhFbkOqdsyOFRnuoXg==",
-            "dev": true,
             "requires": {
                 "pify": "^4.0.0",
                 "with-open-file": "^0.1.3"
@@ -3713,8 +3357,7 @@
                 "pify": {
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-                    "dev": true
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
                 }
             }
         },
@@ -3722,7 +3365,6 @@
             "version": "2.0.13",
             "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
             "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
-            "dev": true,
             "requires": {
                 "glob": "^7.1.1",
                 "graceful-fs": "^4.1.2",
@@ -3735,7 +3377,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
             "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-            "dev": true,
             "requires": {
                 "load-json-file": "^2.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -3746,7 +3387,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
             "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-            "dev": true,
             "requires": {
                 "find-up": "^2.0.0",
                 "read-pkg": "^2.0.0"
@@ -3756,7 +3396,6 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-                    "dev": true,
                     "requires": {
                         "locate-path": "^2.0.0"
                     }
@@ -3767,7 +3406,6 @@
             "version": "2.3.6",
             "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -3782,7 +3420,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
@@ -3791,20 +3428,17 @@
         "repeat-element": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-            "dev": true
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
         },
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "require-uncached": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-            "dev": true,
             "requires": {
                 "caller-path": "^0.1.0",
                 "resolve-from": "^1.0.0"
@@ -3814,7 +3448,6 @@
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
             "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
-            "dev": true,
             "requires": {
                 "path-parse": "^1.0.5"
             }
@@ -3822,20 +3455,17 @@
         "resolve-from": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-            "dev": true
+            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
         },
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-            "dev": true
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "restore-cursor": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-            "dev": true,
             "requires": {
                 "onetime": "^2.0.0",
                 "signal-exit": "^3.0.2"
@@ -3845,7 +3475,6 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
             "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-            "dev": true,
             "requires": {
                 "through": "~2.3.4"
             }
@@ -3853,14 +3482,12 @@
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-            "dev": true
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
         },
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-            "dev": true,
             "requires": {
                 "glob": "^7.0.5"
             }
@@ -3869,7 +3496,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-            "dev": true,
             "requires": {
                 "is-promise": "^2.1.0"
             }
@@ -3877,20 +3503,17 @@
         "run-parallel": {
             "version": "1.1.9",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-            "dev": true
+            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
         },
         "rx-lite": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-            "dev": true
+            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
         },
         "rx-lite-aggregates": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-            "dev": true,
             "requires": {
                 "rx-lite": "*"
             }
@@ -3898,14 +3521,12 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safe-regex": {
             "version": "1.1.0",
             "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-            "dev": true,
             "requires": {
                 "ret": "~0.1.10"
             }
@@ -3913,26 +3534,22 @@
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
             "version": "1.1.4",
             "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
-            "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk=",
-            "dev": true
+            "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk="
         },
         "semver": {
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-            "dev": true
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         },
         "send": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
             "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-            "dev": true,
             "requires": {
                 "debug": "2.6.9",
                 "depd": "~1.1.2",
@@ -3953,7 +3570,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -3961,8 +3577,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -3970,7 +3585,6 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-            "dev": true,
             "requires": {
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
@@ -3982,7 +3596,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-extendable": "^0.1.1",
@@ -3994,7 +3607,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -4004,17 +3616,15 @@
         "setprototypeof": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-            "dev": true
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
         "seymour": {
             "version": "4.0.0-nightly.20180628",
             "resolved": "https://registry.npmjs.org/seymour/-/seymour-4.0.0-nightly.20180628.tgz",
             "integrity": "sha512-wUBDlbTsaM+NrCkG34X9s4M+Oixb5rlLsMW47q+Xu0IaqeT11OaRq+FJDQcnLOFhjLcfwZslolK5wijzF8ERJw==",
-            "dev": true,
             "requires": {
-                "cordova-common": "^3.0.0-nightly.2018.10.30.9c6cda3d",
-                "cordova-lib": "^9.0.0-nightly.2018.10.30.a76667d5",
+                "cordova-common": "^3.0.0-nightly.2018.10.31.9c6cda3d",
+                "cordova-lib": "^9.0.0-nightly.2018.10.31.a76667d5",
                 "elementtree": "^0.1.7",
                 "loud-rejection": "^1.6.0"
             }
@@ -4023,7 +3633,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
@@ -4031,32 +3640,27 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "shelljs": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
-            "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
-            "dev": true
+            "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
         },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-            "dev": true
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "slash": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-            "dev": true
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         },
         "slice-ansi": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-            "dev": true,
             "requires": {
                 "is-fullwidth-code-point": "^2.0.0"
             }
@@ -4065,7 +3669,6 @@
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-            "dev": true,
             "requires": {
                 "base": "^0.11.1",
                 "debug": "^2.2.0",
@@ -4081,7 +3684,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -4090,7 +3692,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -4099,7 +3700,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -4107,8 +3707,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -4116,7 +3715,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-            "dev": true,
             "requires": {
                 "define-property": "^1.0.0",
                 "isobject": "^3.0.0",
@@ -4127,7 +3725,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -4136,7 +3733,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -4145,7 +3741,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -4154,7 +3749,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -4167,7 +3761,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.2.0"
             },
@@ -4176,7 +3769,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -4186,14 +3778,12 @@
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-resolve": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-            "dev": true,
             "requires": {
                 "atob": "^2.1.1",
                 "decode-uri-component": "^0.2.0",
@@ -4205,14 +3795,12 @@
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-            "dev": true
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
         "spdx-correct": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
             "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
-            "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -4221,30 +3809,26 @@
         "spdx-exceptions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-            "dev": true
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-            "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-            "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
-            "dev": true
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+            "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
         },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
             }
@@ -4252,14 +3836,12 @@
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "standard": {
             "version": "11.0.1",
             "resolved": "http://registry.npmjs.org/standard/-/standard-11.0.1.tgz",
             "integrity": "sha512-nu0jAcHiSc8H+gJCXeiziMVZNDYi8MuqrYJKxTgjP4xKXZMKm311boqQIzDrYI/ktosltxt2CbDjYQs9ANC8IA==",
-            "dev": true,
             "requires": {
                 "eslint": "~4.18.0",
                 "eslint-config-standard": "11.0.0",
@@ -4276,7 +3858,6 @@
             "version": "8.0.1",
             "resolved": "http://registry.npmjs.org/standard-engine/-/standard-engine-8.0.1.tgz",
             "integrity": "sha512-LA531C3+nljom/XRvdW/hGPXwmilRkaRkENhO3FAGF1Vtq/WtCXzgmnc5S6vUHHsgv534MRy02C1ikMwZXC+tw==",
-            "dev": true,
             "requires": {
                 "deglob": "^2.1.0",
                 "get-stdin": "^6.0.0",
@@ -4288,7 +3869,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-            "dev": true,
             "requires": {
                 "define-property": "^0.2.5",
                 "object-copy": "^0.1.0"
@@ -4298,7 +3878,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -4308,14 +3887,12 @@
         "statuses": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-            "dev": true
+            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         },
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "dev": true,
             "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
@@ -4325,7 +3902,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
             "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
                 "es-abstract": "^1.5.0",
@@ -4336,7 +3912,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -4345,7 +3920,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^3.0.0"
             },
@@ -4353,34 +3927,29 @@
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
                 }
             }
         },
         "strip-bom": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-            "dev": true
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         },
         "strip-json-comments": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "dev": true
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-            "dev": true
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         },
         "table": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-            "dev": true,
             "requires": {
                 "ajv": "^5.2.3",
                 "ajv-keywords": "^2.1.0",
@@ -4394,7 +3963,6 @@
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
             "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
-            "dev": true,
             "requires": {
                 "deep-equal": "~1.0.1",
                 "defined": "~1.0.0",
@@ -4414,20 +3982,17 @@
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
         },
         "through": {
             "version": "2.3.8",
             "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
             "requires": {
                 "os-tmpdir": "~1.0.2"
             }
@@ -4436,7 +4001,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -4445,7 +4009,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -4456,7 +4019,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-            "dev": true,
             "requires": {
                 "define-property": "^2.0.2",
                 "extend-shallow": "^3.0.2",
@@ -4468,7 +4030,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
@@ -4478,7 +4039,6 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-            "dev": true,
             "requires": {
                 "prelude-ls": "~1.1.2"
             }
@@ -4487,7 +4047,6 @@
             "version": "1.6.16",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
             "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-            "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
                 "mime-types": "~2.1.18"
@@ -4496,20 +4055,17 @@
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-            "dev": true
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "underscore": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-            "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-            "dev": true
+            "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
         },
         "union-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
@@ -4521,7 +4077,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -4530,7 +4085,6 @@
                     "version": "0.4.3",
                     "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-extendable": "^0.1.1",
@@ -4543,26 +4097,22 @@
         "uniq": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-            "dev": true
+            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
         },
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-            "dev": true
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
         },
         "unset-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-            "dev": true,
             "requires": {
                 "has-value": "^0.3.1",
                 "isobject": "^3.0.0"
@@ -4572,7 +4122,6 @@
                     "version": "0.3.1",
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-                    "dev": true,
                     "requires": {
                         "get-value": "^2.0.3",
                         "has-values": "^0.1.4",
@@ -4583,7 +4132,6 @@
                             "version": "2.1.0",
                             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                            "dev": true,
                             "requires": {
                                 "isarray": "1.0.0"
                             }
@@ -4593,46 +4141,39 @@
                 "has-values": {
                     "version": "0.1.4",
                     "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-                    "dev": true
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
                 }
             }
         },
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-            "dev": true
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
         "use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-            "dev": true
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
         },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-            "dev": true
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
         "valid-identifier": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/valid-identifier/-/valid-identifier-0.0.1.tgz",
-            "integrity": "sha1-7x1wk6nTKH4/zpLfkW+GFrI/kLQ=",
-            "dev": true
+            "integrity": "sha1-7x1wk6nTKH4/zpLfkW+GFrI/kLQ="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -4642,7 +4183,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
             "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-            "dev": true,
             "requires": {
                 "builtins": "^1.0.3"
             }
@@ -4650,14 +4190,12 @@
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-            "dev": true
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
         },
         "which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -4666,7 +4204,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.4.tgz",
             "integrity": "sha512-BswUwq/x/BYtNFMr4Uw9V+P2uroc9/tcDpZ2RdDHehzwCKJFF1PSIjJmBNfpUE3UQyJmVINRLOW49WTXQMEnvg==",
-            "dev": true,
             "requires": {
                 "p-finally": "^1.0.0",
                 "p-try": "^2.0.0",
@@ -4676,34 +4213,29 @@
                 "p-try": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-                    "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-                    "dev": true
+                    "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
                 },
                 "pify": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
                 }
             }
         },
         "wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-            "dev": true
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-            "dev": true,
             "requires": {
                 "mkdirp": "^0.5.1"
             }
@@ -4711,26 +4243,22 @@
         "xmlbuilder": {
             "version": "9.0.7",
             "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-            "dev": true
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         },
         "xmldom": {
             "version": "0.1.27",
             "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-            "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
-            "dev": true
+            "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
         },
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-            "dev": true
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         },
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-            "dev": true
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         },
         "acorn-jsx": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
@@ -209,7 +209,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -292,21 +292,21 @@
             "dev": true
         },
         "body-parser": {
-            "version": "1.18.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-            "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+            "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
                 "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "~1.1.1",
-                "http-errors": "~1.6.2",
-                "iconv-lite": "0.4.19",
+                "depd": "~1.1.2",
+                "http-errors": "~1.6.3",
+                "iconv-lite": "0.4.23",
                 "on-finished": "~2.3.0",
-                "qs": "6.5.1",
-                "raw-body": "2.3.2",
-                "type-is": "~1.6.15"
+                "qs": "6.5.2",
+                "raw-body": "2.3.3",
+                "type-is": "~1.6.16"
             },
             "dependencies": {
                 "debug": {
@@ -319,9 +319,18 @@
                     }
                 },
                 "iconv-lite": {
-                    "version": "0.4.19",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+                    "version": "0.4.23",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true
                 }
             }
@@ -572,12 +581,12 @@
             "dev": true
         },
         "compressible": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
-            "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
+            "version": "2.0.15",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+            "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
             "dev": true,
             "requires": {
-                "mime-db": ">= 1.34.0 < 2"
+                "mime-db": ">= 1.36.0 < 2"
             }
         },
         "compression": {
@@ -603,6 +612,12 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -882,9 +897,9 @@
             "dev": true
         },
         "cordova-common": {
-            "version": "3.0.0-nightly.2018.9.10.69dd3f94",
-            "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-3.0.0-nightly.2018.9.10.69dd3f94.tgz",
-            "integrity": "sha512-LSnp6cYaavzmxvlZxHVd6eTRrPrm5yEnduKQz4qVDT21V38JA7ZMSpIoAiTr0YrbhpR6keNCgdmNQh+8l2CbiQ==",
+            "version": "3.0.0-nightly.2018.10.30.9c6cda3d",
+            "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-3.0.0-nightly.2018.10.30.9c6cda3d.tgz",
+            "integrity": "sha512-Q2+VoOP75pe4ApwvfGyMdAYOjgDHrtT7CbtxVJ5SoEHqsAz0+8icWpgm2MUoZGDXnW4Cutw68W/5Evbc6E595A==",
             "dev": true,
             "requires": {
                 "ansi": "^0.3.1",
@@ -902,37 +917,53 @@
             }
         },
         "cordova-create": {
-            "version": "1.1.3-nightly.2018.9.10.c772d1e1",
-            "resolved": "https://registry.npmjs.org/cordova-create/-/cordova-create-1.1.3-nightly.2018.9.10.c772d1e1.tgz",
-            "integrity": "sha512-opWNgfa6/vYGw1vbkvjflNILMhohIe4GmWRnpsmXNeOBx4jnVt6g8wNv4YoxYjHONBArVOrNFSG9KIKRGdxwWg==",
+            "version": "2.0.0-nightly.2018.10.30.5e3aab63",
+            "resolved": "https://registry.npmjs.org/cordova-create/-/cordova-create-2.0.0-nightly.2018.10.30.5e3aab63.tgz",
+            "integrity": "sha512-bxddlwH5SoWLD4ZZMSWAznWkqpiXIWoR4XHLcppLbRmGSAORo45LbCe4UzGkJltG4IOrcIbVqJ+yj7i5akNQUg==",
             "dev": true,
             "requires": {
                 "cordova-app-hello-world": "^3.11.0",
-                "cordova-common": "3.0.0-nightly.2018.9.10.69dd3f94",
-                "cordova-fetch": "2.0.0-nightly.2018.9.10.4152a0d2",
+                "cordova-common": "3.0.0-nightly.2018.10.30.9c6cda3d",
+                "cordova-fetch": "2.0.0-nightly.2018.10.30.fef644a7",
                 "fs-extra": "^6.0.1",
                 "import-fresh": "^2.0.0",
                 "is-url": "^1.2.4",
                 "isobject": "^3.0.1",
                 "path-is-inside": "^1.0.2",
-                "q": "^1.5.1",
                 "tmp": "0.0.33",
                 "valid-identifier": "0.0.1"
             }
         },
         "cordova-fetch": {
-            "version": "2.0.0-nightly.2018.9.10.4152a0d2",
-            "resolved": "https://registry.npmjs.org/cordova-fetch/-/cordova-fetch-2.0.0-nightly.2018.9.10.4152a0d2.tgz",
-            "integrity": "sha512-536UyfUSF0sbWyJKf5R92levwHTD4zpcydPe+W6/penH3SM94y6Oax7fSdtfTdLpZHjElSO3zSptXkQxR/DR6Q==",
+            "version": "2.0.0-nightly.2018.10.30.fef644a7",
+            "resolved": "https://registry.npmjs.org/cordova-fetch/-/cordova-fetch-2.0.0-nightly.2018.10.30.fef644a7.tgz",
+            "integrity": "sha512-mHjy11WRvt4/b2Mtt7Y4hrA6ebi5MxDI9zzxlx5NFrtxxcx5VbAqU8+eL3zckZ7hUu17wz2IXpCER8nM/MEk7w==",
             "dev": true,
             "requires": {
-                "cordova-common": "3.0.0-nightly.2018.9.10.69dd3f94",
+                "cordova-common": "3.0.0-nightly.2018.10.30.9c6cda3d",
                 "fs-extra": "^6.0.1",
-                "get-installed-path": "^4.0.8",
                 "npm-package-arg": "^6.1.0",
-                "q": "^1.4.1",
+                "pify": "^4.0.0",
+                "resolve": "^1.8.1",
                 "semver": "^5.5.0",
                 "which": "^1.3.1"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.8.1",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+                    "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.5"
+                    }
+                }
             }
         },
         "cordova-ios": {
@@ -1243,14 +1274,14 @@
             }
         },
         "cordova-lib": {
-            "version": "8.0.1-nightly.2018.9.10.1bc9dd05",
-            "resolved": "https://registry.npmjs.org/cordova-lib/-/cordova-lib-8.0.1-nightly.2018.9.10.1bc9dd05.tgz",
-            "integrity": "sha512-YkWYVG0Rjnf5lwWshXvOfYP+Lcclv8CpoiGGa5m5uhIhgCygGUSPpCwuEcKH//asMFJl8r5/NrnPCO064s5C/g==",
+            "version": "9.0.0-nightly.2018.10.30.a76667d5",
+            "resolved": "https://registry.npmjs.org/cordova-lib/-/cordova-lib-9.0.0-nightly.2018.10.30.a76667d5.tgz",
+            "integrity": "sha512-oC7qU4KdebnLHdqGsjk5mQwy8wyi58IwS2p6jaDAZcfkMKhM/oYYidEcHfOC4nNJJEWzi5eJTiL9K7udix5CEg==",
             "dev": true,
             "requires": {
-                "cordova-common": "3.0.0-nightly.2018.9.10.69dd3f94",
-                "cordova-create": "1.1.3-nightly.2018.9.10.c772d1e1",
-                "cordova-fetch": "2.0.0-nightly.2018.9.10.4152a0d2",
+                "cordova-common": "3.0.0-nightly.2018.10.30.9c6cda3d",
+                "cordova-create": "2.0.0-nightly.2018.10.30.5e3aab63",
+                "cordova-fetch": "2.0.0-nightly.2018.10.30.fef644a7",
                 "cordova-serve": "^2.0.0",
                 "dep-graph": "1.1.0",
                 "detect-indent": "^5.0.0",
@@ -1259,7 +1290,7 @@
                 "globby": "^8.0.1",
                 "indent-string": "^3.2.0",
                 "init-package-json": "^1.2.0",
-                "q": "^1.5.1",
+                "md5-file": "^4.0.0",
                 "read-chunk": "^3.0.0",
                 "semver": "^5.3.0",
                 "shebang-command": "^1.2.0",
@@ -1301,13 +1332,13 @@
             }
         },
         "cordova-plugin-ayogo-push": {
-            "version": "github:AyogoHealth/cordova-plugin-ayogo-push#9442e51de99b9ff5068aae32743554cde2e3b355",
+            "version": "github:AyogoHealth/cordova-plugin-ayogo-push#32b99a4e23a208a5190e7b2a55a65dbef2894895",
             "from": "github:AyogoHealth/cordova-plugin-ayogo-push"
         },
         "cordova-plugin-code-push": {
-            "version": "1.11.12",
-            "resolved": "https://registry.npmjs.org/cordova-plugin-code-push/-/cordova-plugin-code-push-1.11.12.tgz",
-            "integrity": "sha512-STA/RUbjFt0kCwRRhaBao9yQ8SxeJlXl8K2SF1yakXsmHh7OeR1n1265ZdYIREJZT/9HCQYVkpptnWKKH4sJbw=="
+            "version": "1.11.13",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-code-push/-/cordova-plugin-code-push-1.11.13.tgz",
+            "integrity": "sha512-70uGZfmaiK4fxjLg9f45f5DYoJUwiX8Zm1+iRpDek+uyVraIPut3he1n1KBfll8K3ic5WCU0NzGOjYcDaxAllw=="
         },
         "cordova-plugin-device": {
             "version": "2.0.2",
@@ -1367,7 +1398,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -1403,12 +1434,12 @@
             }
         },
         "debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
             "dev": true,
             "requires": {
-                "ms": "2.0.0"
+                "ms": "^2.1.1"
             }
         },
         "debug-log": {
@@ -1654,14 +1685,14 @@
             }
         },
         "es-to-primitive": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-            "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
             "dev": true,
             "requires": {
-                "is-callable": "^1.1.1",
+                "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.1"
+                "is-symbol": "^1.0.2"
             }
         },
         "escape-html": {
@@ -1751,6 +1782,12 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -1772,12 +1809,18 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
         "eslint-plugin-import": {
             "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
+            "resolved": "http://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
             "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
             "dev": true,
             "requires": {
@@ -1811,12 +1854,18 @@
                         "esutils": "^2.0.2",
                         "isarray": "^1.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
         "eslint-plugin-node": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
             "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
             "dev": true,
             "requires": {
@@ -1834,7 +1883,7 @@
         },
         "eslint-plugin-react": {
             "version": "7.7.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
+            "resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
             "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
             "dev": true,
             "requires": {
@@ -1868,7 +1917,7 @@
         },
         "espree": {
             "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+            "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "dev": true,
             "requires": {
@@ -1959,27 +2008,24 @@
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
-        "expand-tilde": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-            "dev": true,
-            "requires": {
-                "homedir-polyfill": "^1.0.1"
-            }
-        },
         "express": {
-            "version": "4.16.3",
-            "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
-            "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+            "version": "4.16.4",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+            "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.5",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.18.2",
+                "body-parser": "1.18.3",
                 "content-disposition": "0.5.2",
                 "content-type": "~1.0.4",
                 "cookie": "0.3.1",
@@ -1996,10 +2042,10 @@
                 "on-finished": "~2.3.0",
                 "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.3",
-                "qs": "6.5.1",
+                "proxy-addr": "~2.0.4",
+                "qs": "6.5.2",
                 "range-parser": "~1.2.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
@@ -2018,10 +2064,10 @@
                         "ms": "2.0.0"
                     }
                 },
-                "safe-buffer": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true
                 }
             }
@@ -2125,14 +2171,14 @@
         },
         "fast-deep-equal": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
             "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
             "dev": true
         },
         "fast-glob": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
-            "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.3.tgz",
+            "integrity": "sha512-NiX+JXjnx43RzvVFwRWfPKo4U+1BrK5pJPsHQdKMlLoFHrrGktXglQhHliSihWAq+m1z6fHk3uwGHrtRbS9vLA==",
             "dev": true,
             "requires": {
                 "@mrmlnc/readdir-enhanced": "^2.2.1",
@@ -2205,7 +2251,7 @@
         },
         "finalhandler": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "dev": true,
             "requires": {
@@ -2226,6 +2272,12 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -2322,15 +2374,6 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
-        "get-installed-path": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/get-installed-path/-/get-installed-path-4.0.8.tgz",
-            "integrity": "sha512-PmANK1xElIHlHH2tXfOoTnSDUjX1X3GvKK6ZyLbUnSCCn1pADwu67eVWttuPzJWrXDDT2MfO6uAaKILOFfitmA==",
-            "dev": true,
-            "requires": {
-                "global-modules": "1.0.0"
-            }
-        },
         "get-stdin": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -2384,34 +2427,10 @@
             "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
             "dev": true
         },
-        "global-modules": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-            "dev": true,
-            "requires": {
-                "global-prefix": "^1.0.1",
-                "is-windows": "^1.0.1",
-                "resolve-dir": "^1.0.0"
-            }
-        },
-        "global-prefix": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-            "dev": true,
-            "requires": {
-                "expand-tilde": "^2.0.2",
-                "homedir-polyfill": "^1.0.1",
-                "ini": "^1.3.4",
-                "is-windows": "^1.0.1",
-                "which": "^1.2.14"
-            }
-        },
         "globals": {
-            "version": "11.7.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-            "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+            "version": "11.8.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+            "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
             "dev": true
         },
         "globby": {
@@ -2458,6 +2477,12 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "dev": true
+        },
         "has-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -2488,15 +2513,6 @@
                         "is-buffer": "^1.1.5"
                     }
                 }
-            }
-        },
-        "homedir-polyfill": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-            "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-            "dev": true,
-            "requires": {
-                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -2587,12 +2603,6 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
             "dev": true
         },
-        "ini": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-            "dev": true
-        },
         "init-package-json": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
@@ -2671,7 +2681,7 @@
         },
         "is-builtin-module": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
@@ -2831,10 +2841,13 @@
             "dev": true
         },
         "is-symbol": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-            "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-            "dev": true
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.0"
+            }
         },
         "is-url": {
             "version": "1.2.4",
@@ -2942,7 +2955,7 @@
         },
         "load-json-file": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
             "dev": true,
             "requires": {
@@ -2971,9 +2984,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.10",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+            "version": "4.17.11",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
             "dev": true
         },
         "loose-envify": {
@@ -3020,9 +3033,15 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "md5-file": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
+            "integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg==",
+            "dev": true
+        },
         "media-typer": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
         },
@@ -3033,9 +3052,9 @@
             "dev": true
         },
         "merge2": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
-            "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+            "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
             "dev": true
         },
         "methods": {
@@ -3072,18 +3091,18 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.36.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-            "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.20",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-            "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+            "version": "2.1.21",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.36.0"
+                "mime-db": "~1.37.0"
             }
         },
         "mimic-fn": {
@@ -3146,9 +3165,9 @@
             }
         },
         "ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
             "dev": true
         },
         "mute-stream": {
@@ -3322,9 +3341,9 @@
             }
         },
         "opn": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
-            "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+            "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
             "dev": true,
             "requires": {
                 "is-wsl": "^1.1.0"
@@ -3405,12 +3424,6 @@
                 "error-ex": "^1.2.0"
             }
         },
-        "parse-passwd": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-            "dev": true
-        },
         "parseurl": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
@@ -3473,7 +3486,7 @@
         },
         "pify": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
             "dev": true
         },
@@ -3597,9 +3610,9 @@
             "dev": true
         },
         "progress": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+            "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
             "dev": true
         },
         "promzard": {
@@ -3644,9 +3657,9 @@
             "dev": true
         },
         "qs": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
         "range-parser": {
@@ -3656,46 +3669,25 @@
             "dev": true
         },
         "raw-body": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-            "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+            "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "http-errors": "1.6.2",
-                "iconv-lite": "0.4.19",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.23",
                 "unpipe": "1.0.0"
             },
             "dependencies": {
-                "depd": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-                    "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-                    "dev": true
-                },
-                "http-errors": {
-                    "version": "1.6.2",
-                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-                    "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+                "iconv-lite": {
+                    "version": "0.4.23",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
                     "dev": true,
                     "requires": {
-                        "depd": "1.1.1",
-                        "inherits": "2.0.3",
-                        "setprototypeof": "1.0.3",
-                        "statuses": ">= 1.3.1 < 2"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
-                },
-                "iconv-lite": {
-                    "version": "0.4.19",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-                    "dev": true
-                },
-                "setprototypeof": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-                    "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-                    "dev": true
                 }
             }
         },
@@ -3719,9 +3711,9 @@
             },
             "dependencies": {
                 "pify": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.0.tgz",
-                    "integrity": "sha512-zrSP/KDf9DH3K3VePONoCstgPiYJy9z0SCatZuTpOc7YdnWIqwkWdXOuwlr4uDc7em8QZRsFWsT/685x5InjYg==",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
                     "dev": true
                 }
             }
@@ -3827,16 +3819,6 @@
                 "path-parse": "^1.0.5"
             }
         },
-        "resolve-dir": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-            "dev": true,
-            "requires": {
-                "expand-tilde": "^2.0.0",
-                "global-modules": "^1.0.0"
-            }
-        },
         "resolve-from": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
@@ -3921,7 +3903,7 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
@@ -3941,9 +3923,9 @@
             "dev": true
         },
         "semver": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-            "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
             "dev": true
         },
         "send": {
@@ -3975,6 +3957,12 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -4025,8 +4013,8 @@
             "integrity": "sha512-wUBDlbTsaM+NrCkG34X9s4M+Oixb5rlLsMW47q+Xu0IaqeT11OaRq+FJDQcnLOFhjLcfwZslolK5wijzF8ERJw==",
             "dev": true,
             "requires": {
-                "cordova-common": "^3.0.0-nightly.2018.9.10.69dd3f94",
-                "cordova-lib": "^8.0.1-nightly.2018.9.10.1bc9dd05",
+                "cordova-common": "^3.0.0-nightly.2018.10.30.9c6cda3d",
+                "cordova-lib": "^9.0.0-nightly.2018.10.30.a76667d5",
                 "elementtree": "^0.1.7",
                 "loud-rejection": "^1.6.0"
             }
@@ -4115,6 +4103,12 @@
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -4215,9 +4209,9 @@
             "dev": true
         },
         "spdx-correct": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+            "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
             "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
@@ -4225,9 +4219,9 @@
             }
         },
         "spdx-exceptions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
             "dev": true
         },
         "spdx-expression-parse": {
@@ -4425,7 +4419,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
@@ -4669,9 +4663,9 @@
             }
         },
         "with-open-file": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.3.tgz",
-            "integrity": "sha512-sPUMcyWU0wde5lnHuDeEgAOIV4y77GpGmh9ktxb5HBfA2OwyWY7JtQYbBxuUFf/yv8Sbfrkxk+QbQwAyurvgXQ==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.4.tgz",
+            "integrity": "sha512-BswUwq/x/BYtNFMr4Uw9V+P2uroc9/tcDpZ2RdDHehzwCKJFF1PSIjJmBNfpUE3UQyJmVINRLOW49WTXQMEnvg==",
             "dev": true,
             "requires": {
                 "p-finally": "^1.0.0",
@@ -4716,7 +4710,7 @@
         },
         "xmlbuilder": {
             "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
             "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
             "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "cordova-plugin-file": "^6.0.0",
         "cordova-plugin-file-transfer": "^1.7.0",
         "cordova-plugin-whitelist": "^1.3.3",
-        "cordova-plugin-zip": "^3.1.0"
+        "cordova-plugin-zip": "^3.1.0",
+        "seymour": "nightly"
     },
     "cordova": {
         "platforms": [
@@ -33,8 +34,5 @@
             "cordova-plugin-zip": {},
             "cordova-plugin-code-push": {}
         }
-    },
-    "devDependencies": {
-        "seymour": "nightly"
     }
 }


### PR DESCRIPTION
Let's see if the npm logs give us any clue as to why it's completely trashing node_modules